### PR TITLE
Add option to store unconstrained draws and update stan interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ version = "0.17.1"
 features = ["extension-module", "auto-initialize"]
 
 [dev-dependencies]
-criterion = "0.3.5"
+criterion = "0.4.0"
 
 [profile.release]
 debug = true

--- a/nutpie/compile_pymc.py
+++ b/nutpie/compile_pymc.py
@@ -135,7 +135,7 @@ def compile_pymc_model(model, **kwargs):
     )
     logp_numba = numba.cfunc(c_sig, **kwargs)(logp_numba_raw)
 
-    def expand_draw(x, shared_data):
+    def expand_draw(x, seed, chain, draw, *, shared_data):
         return expand_fn(x, **{name: shared_data[name] for name in shared_expand})[0]
 
     def make_logp_pyfn(data_ptr):
@@ -260,7 +260,7 @@ def _make_functions(model):
     expand_fn = expand_fn_at.vm.jit_fn
     # expand_fn = numba.njit(expand_fn, fastmath=True, error_model="numpy")
     # Trigger a compile
-    expand_fn(np.zeros(num_free_vars))
+    expand_fn(np.zeros(num_free_vars), *[var.get_value() for var in expand_fn_at.get_shared()])
 
     return (
         num_free_vars,

--- a/nutpie/compile_stan.py
+++ b/nutpie/compile_stan.py
@@ -61,8 +61,8 @@ def compile_stan_model(
 
     logp_maker = _make_logp_maker(stan_lib, data)
 
-    def expanding_function(x):
-        return stan_lib.write_array_ctx(ctx, x, True, True, 0)
+    def expanding_function(x, seed, chain, draw):
+        return stan_lib.write_array_ctx(ctx, x, True, True, seed + 10000 * chain + draw)
 
     return CompiledStanModel(
         n_dim,

--- a/nutpie/sample.py
+++ b/nutpie/sample.py
@@ -59,6 +59,28 @@ def sample(
         transitions happend in the sampler stats.
     progress_bar: bool
         If true, display the progress bar (default)
+    init_mean: ndarray
+        Initialize the chains using jittered values around this
+        point on the transformed parameter space. Defaults to
+        zeros.
+    store_unconstrained: bool
+        If True, store each draw in the unconstrained (transformed)
+        space in the sample stats.
+    store_gradient: bool
+        If True, store the logp gradient of each draw in the unconstrained
+        space in the sample stats.
+    store_mass_matrix: bool
+        If True, store the current mass matrix at each draw in
+        the sample stats.
+    target_accept: float between 0 and 1, default 0.8
+        Adapt the step size of the integrator so that the average
+        acceptance probability of the draws is `target_accept`.
+        Larger values will decrease the step size of the integrator,
+        which can help when sampling models with bad geometry.
+    maxdepth: int, default=10
+        The maximum depth of the tree for each draw. The maximum
+        number of gradient evaluations for each draw will
+        be 2 ^ maxdepth.
     **kwargs
         Pass additional arguments to nutpie.lib.PySamplerArgs
     """

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,6 @@ struct ErrorCode(std::os::raw::c_int);
 
 impl LogpError for ErrorCode {
     fn is_recoverable(&self) -> bool {
-        assert!(self.0 > 0, "{}", self.0);
         self.0 > 0
     }
 }


### PR DESCRIPTION
- `sample(store_unconstrained=True)` will add an additional sampling stat, the current draw in unconstrained space. This can be useful for debugging.
- The stan interface was a bit outdated. We should add tests for those, this is a bit tricky though because they require a patched httpstan (mentioned in the readme)
- We also pass seed chain and draw to the sample expanding function, I think that needs to be set in the stan expansion function to get good generated quantities (that might be random...)