### PR TITLE
Bump version to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nutpie"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Adrian Seyboldt <adrian.seyboldt@gmail.com>"]
 edition = "2021"
 


### PR DESCRIPTION
This release switches from nuts-rs 0.3 to 0.4 and changes the default number of tuning steps to 300.