### PR TITLE
Fix error due to move of aeppl to pymc

### DIFF
--- a/nutpie/compile_pymc.py
+++ b/nutpie/compile_pymc.py
@@ -10,7 +10,7 @@ from numpy.typing import NDArray
 import pymc as pm
 import numpy as np
 import numba
-from aeppl.logprob import CheckParameterValue
+from aesara.raise_op import CheckAndRaise
 import aesara.link.numba.dispatch
 from numba import literal_unroll
 from numba.cpython.unsafe.tuple import alloca_once, tuple_setitem
@@ -21,8 +21,8 @@ from . import lib
 
 # Provide a numba implementation for CheckParameterValue,
 # which doesn't exist in aesara
-@aesara.link.numba.dispatch.basic.numba_funcify.register(CheckParameterValue)
-def numba_functify_CheckParameterValue(op, **kwargs):
+@aesara.link.numba.dispatch.basic.numba_funcify.register(CheckAndRaise)
+def numba_functify_CheckAndRaise(op, **kwargs):
     msg = f"Invalid parameter value {str(op)}"
 
     @aesara.link.numba.dispatch.basic.numba_njit


### PR DESCRIPTION
fixes #16
Importing aeppl tries to register rewrites that already are added by pymc now.
We can avoid that by not importing aeppl at all. We only imported it to implement a missing op, but we can simply implement a super-op of that.