### PR TITLE
Remove unnecessary align in the user_data dtype

### DIFF
--- a/nutpie/compile_pymc.py
+++ b/nutpie/compile_pymc.py
@@ -93,7 +93,6 @@ def make_user_data(func, shared_data):
                 ],
             )
         ],
-        align=True,
     )
     user_data = np.zeros((), dtype=record_dtype)
     update_user_data(user_data, shared_data)


### PR DESCRIPTION
This leads to incorrect alignment computations in numpy if user_data is empty.

Fixes #38.