### PR TITLE
Rename to avoid clobber of tests with the same name

### DIFF
--- a/tests/test_pymc.py
+++ b/tests/test_pymc.py
@@ -15,7 +15,7 @@ def test_pymc_model():
     trace.posterior.a
 
 
-def test_pymc_model():
+def test_pymc_model_with_coordinate():
     with pm.Model() as model:
         model.add_coord("foo", length=5)
         pm.Normal("a", dims="foo")


### PR DESCRIPTION
There were two tests named `test_pymc_model`. This renames one of them to `test_pymc_model_with_coordinate`.