### PR TITLE
Add citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: nutpie
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Adrian
+    family-names: Seyboldt
+    email: adrian.seyboldt@gmail.com
+    affiliation: PyMC Labs
+    orcid: 'https://orcid.org/0000-0002-4239-4541'
+  - name: PyMC Developers
+    website: 'https://github.com/pymc-devs/'
+repository-code: 'https://github.com/pymc-devs/nutpie'
+abstract: 'A fast sampler for Bayesian posteriors, wrapping nuts-rs.'
+keywords:
+  - NUTS
+  - Bayesian inference
+  - MCMC
+license: MIT


### PR DESCRIPTION
As proposed on Slack, this adds a `CITATION.cff` to make the project citable.

I looked at the contributor graph, and since @aseyboldt did the vast majority of work, I just summarized everybody else under "PyMC Developers".