### PR TITLE
Set 'make_initial_point_fn' in 'from_pyfunc' to None by default

### DIFF
--- a/python/nutpie/compiled_pyfunc.py
+++ b/python/nutpie/compiled_pyfunc.py
@@ -80,7 +80,7 @@ def from_pyfunc(
     coords: dict[str, Any] | None = None,
     dims: dict[str, tuple[str, ...]] | None = None,
     shared_data: dict[str, Any] | None = None,
-    make_initial_point_fn: Callable[[SeedType], np.ndarray] | None,
+    make_initial_point_fn: Callable[[SeedType], np.ndarray] | None = None,
 ):
     variables = []
     for name, shape, dtype in zip(


### PR DESCRIPTION
This is causing issues in libraries like Bayeux and Bambi 

See https://github.com/jax-ml/bayeux/issues/65 and https://github.com/bambinos/bambi/issues/887#issuecomment-2682351063