### PR TITLE
Add trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
     needs: [linux, windows, macos, sdist]
+    environment:
+      name: pypi
     permissions:
       # Use to sign the release artifacts
       id-token: write
@@ -275,8 +277,6 @@ jobs:
       - name: Publish to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*


### PR DESCRIPTION
We switched PyPI over to the `pymc-devs` org, and so now the old token shouldn't work. This is an excellent opportunity to switch to trusted publishing. I've already set up the link on PyPI.

![image](https://github.com/user-attachments/assets/139a7b81-7c91-40bf-9c38-37410fdb1654)

On the GitHub side, before merging this, all we need to do is go under Settings -> Environments and create a new environment called `pypi` and configure required reviewers. (I don't personally have the necessary permissions, so you'll have to do it @aseyboldt)

IMPORTANT: ensure that you click "Save protection rules" as pictured when configuring required reviewers, otherwise this will create a big security hole:

![image](https://github.com/user-attachments/assets/65b1f9f8-3a1f-4295-8b5d-2996628fdc39)
