### PR TITLE
Fix call to pm.sample in docs

### DIFF
--- a/docs/pymc-usage.qmd
+++ b/docs/pymc-usage.qmd
@@ -82,7 +82,7 @@ Alternatively, we can also sample through the `pymc` API:
 
 ```python
 with model:
-    trace = pm.sample(model, nuts_sampler="nutpie")
+    trace = pm.sample(nuts_sampler="nutpie")
 ```
 
 While sampling, nutpie shows a progress bar for each chain. It also includes
@@ -138,7 +138,6 @@ Or through the pymc API:
 ```python
 with model:
     trace = pm.sample(
-        model,
         nuts_sampler="nutpie",
         nuts_sampler_kwargs={"backend": "jax"},
     )


### PR DESCRIPTION
Using the docs example:
```
with model:
    trace = pm.sample(
        model,
        nuts_sampler="nutpie",
        nuts_sampler_kwargs={"backend": "jax"},
    )
```
Results in:
`TypeError: '<' not supported between instances of 'Model' and 'int'`

This is because model is not the first argument for pm.sample when in the `with` block.