### PR TITLE
Add log-likelhood calculation to sampling

### DIFF
--- a/python/nutpie/compile_pymc.py
+++ b/python/nutpie/compile_pymc.py
@@ -111,6 +111,8 @@ class CompiledPyMCModel(CompiledModel):
     _n_dim: int
     _shapes: dict[str, tuple[int, ...]]
     _coords: Optional[dict[str, Any]]
+    log_likelihood_names: list[str]
+    log_likelihood_shapes: list[tuple[int, ...]]
 
     @property
     def n_dim(self):
@@ -220,6 +222,7 @@ def _compile_pymc_model_numba(
     model: "pm.Model",
     pymc_initial_point_fn: Callable[[SeedType], dict[str, np.ndarray]],
     var_names: Iterable[str] | None = None,
+    compute_log_likelihood: bool = False,
     **kwargs,
 ) -> CompiledPyMCModel:
     if find_spec("numba") is None:
@@ -238,6 +241,7 @@ def _compile_pymc_model_numba(
         expand_fn_pt,
         initial_point_fn,
         shape_info,
+        log_likelihood_info,
     ) = _make_functions(
         model,
         mode="NUMBA",
@@ -245,6 +249,7 @@ def _compile_pymc_model_numba(
         join_expanded=True,
         pymc_initial_point_fn=pymc_initial_point_fn,
         var_names=var_names,
+        compute_log_likelihood=compute_log_likelihood,
     )
 
     expand_fn = expand_fn_pt.vm.jit_fn
@@ -254,6 +259,9 @@ def _compile_pymc_model_numba(
     shared_vars = {}
     seen = set()
     for val in [*logp_fn_pt.get_shared(), *expand_fn_pt.get_shared()]:
+        # Skip RNG variables that don't have names
+        if val.name is None:
+            continue
         if val.name in shared_data and val not in seen:
             raise ValueError(f"Shared variables must have unique names: {val.name}")
         shared_data[val.name] = np.array(val.get_value(), order="C", copy=True)
@@ -265,10 +273,14 @@ def _compile_pymc_model_numba(
 
     user_data = make_user_data(shared_vars, shared_data)
 
-    logp_shared_names = [var.name for var in logp_fn_pt.get_shared()]
+    logp_shared_names = [var.name for var in logp_fn_pt.get_shared() if var.name is not None]
     logp_numba_raw, c_sig = _make_c_logp_func(
         n_dim, logp_fn, user_data, logp_shared_names, shared_data
     )
+    
+    # Filter out compute_log_likelihood from kwargs for numba compilation
+    numba_kwargs = {k: v for k, v in kwargs.items() if k != 'compute_log_likelihood'}
+    
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
@@ -276,9 +288,9 @@ def _compile_pymc_model_numba(
             category=numba.NumbaWarning,  # type: ignore
         )
 
-        logp_numba = numba.cfunc(c_sig, **kwargs)(logp_numba_raw)
+        logp_numba = numba.cfunc(c_sig, **numba_kwargs)(logp_numba_raw)
 
-    expand_shared_names = [var.name for var in expand_fn_pt.get_shared()]
+    expand_shared_names = [var.name for var in expand_fn_pt.get_shared() if var.name is not None]
     expand_numba_raw, c_sig_expand = _make_c_expand_func(
         n_dim, n_expanded, expand_fn, user_data, expand_shared_names, shared_data
     )
@@ -289,10 +301,12 @@ def _compile_pymc_model_numba(
             category=numba.NumbaWarning,  # type: ignore
         )
 
-        expand_numba = numba.cfunc(c_sig_expand, **kwargs)(expand_numba_raw)
+        expand_numba = numba.cfunc(c_sig_expand, **numba_kwargs)(expand_numba_raw)
 
     dims, coords = _prepare_dims_and_coords(model, shape_info)
 
+    log_likelihood_names, log_likelihood_shapes = log_likelihood_info
+    
     return CompiledPyMCModel(
         _n_dim=n_dim,
         dims=dims,
@@ -307,6 +321,8 @@ def _compile_pymc_model_numba(
         shape_info=shape_info,
         logp_func=logp_fn_pt,
         expand_func=expand_fn_pt,
+        log_likelihood_names=log_likelihood_names,
+        log_likelihood_shapes=log_likelihood_shapes,
     )
 
 
@@ -341,6 +357,7 @@ def _compile_pymc_model_jax(
     gradient_backend=None,
     pymc_initial_point_fn: Callable[[SeedType], dict[str, np.ndarray]],
     var_names: Iterable[str] | None = None,
+    compute_log_likelihood: bool = False,
     **kwargs,
 ):
     if find_spec("jax") is None:
@@ -364,6 +381,7 @@ def _compile_pymc_model_jax(
         expand_fn_pt,
         initial_point_fn,
         shape_info,
+        log_likelihood_info,
     ) = _make_functions(
         model,
         mode="JAX",
@@ -371,13 +389,14 @@ def _compile_pymc_model_jax(
         join_expanded=False,
         pymc_initial_point_fn=pymc_initial_point_fn,
         var_names=var_names,
+        compute_log_likelihood=compute_log_likelihood,
     )
 
     logp_fn = logp_fn_pt.vm.jit_fn
     expand_fn = expand_fn_pt.vm.jit_fn
 
-    logp_shared_names = [var.name for var in logp_fn_pt.get_shared()]
-    expand_shared_names = [var.name for var in expand_fn_pt.get_shared()]
+    logp_shared_names = [var.name for var in logp_fn_pt.get_shared() if var.name is not None]
+    expand_shared_names = [var.name for var in expand_fn_pt.get_shared() if var.name is not None]
 
     if gradient_backend == "jax":
         orig_logp_fn = logp_fn._fun
@@ -399,6 +418,9 @@ def _compile_pymc_model_jax(
     shared_vars = {}
     seen = set()
     for val in [*logp_fn_pt.get_shared(), *expand_fn_pt.get_shared()]:
+        # Skip RNG variables that don't have names
+        if val.name is None:
+            continue
         if val.name in shared_data and val not in seen:
             raise ValueError(f"Shared variables must have unique names: {val.name}")
         shared_data[val.name] = jax.numpy.asarray(val.get_value())
@@ -428,6 +450,7 @@ def _compile_pymc_model_jax(
         return expand
 
     dims, coords = _prepare_dims_and_coords(model, shape_info)
+    log_likelihood_names, log_likelihood_shapes = log_likelihood_info
 
     return from_pyfunc(
         ndim=n_dim,
@@ -441,6 +464,8 @@ def _compile_pymc_model_jax(
         dims=dims,
         coords=coords,
         raw_logp_fn=orig_logp_fn,
+        log_likelihood_names=log_likelihood_names,
+        log_likelihood_shapes=log_likelihood_shapes,
     )
 
 
@@ -457,6 +482,7 @@ def compile_pymc_model(
     ] = "support_point",
     var_names: Iterable[str] | None = None,
     freeze_model: bool | None = None,
+    compute_log_likelihood: bool = False,
     **kwargs,
 ) -> CompiledModel:
     """Compile necessary functions for sampling a pymc model.
@@ -485,6 +511,9 @@ def compile_pymc_model(
     freeze_model : bool | None
         Freeze all dimensions and shared variables to treat them as compile time
         constants.
+    compute_log_likelihood : bool
+        Whether to compute element-wise log-likelihood values for observed variables.
+        When True, enables population of the log_likelihood group in ArviZ InferenceData.
     Returns
     -------
     compiled_model : CompiledPyMCModel
@@ -533,6 +562,7 @@ def compile_pymc_model(
             model=model,
             pymc_initial_point_fn=initial_point_fn,
             var_names=var_names,
+            compute_log_likelihood=compute_log_likelihood,
             **kwargs,
         )
     elif backend.lower() == "jax":
@@ -541,6 +571,7 @@ def compile_pymc_model(
             gradient_backend=gradient_backend,
             pymc_initial_point_fn=initial_point_fn,
             var_names=var_names,
+            compute_log_likelihood=compute_log_likelihood,
             **kwargs,
         )
     else:
@@ -595,6 +626,7 @@ def _make_functions(
     join_expanded: bool,
     pymc_initial_point_fn: Callable[[SeedType], dict[str, np.ndarray]],
     var_names: Iterable[str] | None = None,
+    compute_log_likelihood: bool = False,
 ) -> tuple[
     int,
     int,
@@ -602,6 +634,7 @@ def _make_functions(
     Callable,
     Callable,
     tuple[list[str], list[slice], list[tuple[int, ...]]],
+    tuple[list[str], list[tuple[int, ...]]],
 ]:
     """
     Compile functions required by nuts-rs from a given PyMC model.
@@ -623,6 +656,8 @@ def _make_functions(
         pymc.initial_point.make_initial_point_fn
     var_names:
         Names of variables to store in the trace. Defaults to all variables.
+    compute_log_likelihood: bool
+        Whether to compute element-wise log-likelihood values for observed variables.
 
     Returns
     -------
@@ -646,10 +681,14 @@ def _make_functions(
         names of the variables, the second list contains the slices that
         correspond to the variables in the flat array, and the third list
         contains the shapes of the variables.
+    log_likelihood_data: tuple of lists
+        Tuple containing log-likelihood variable information. The first list contains
+        the names of the log-likelihood variables, the second list contains their shapes.
     """
     import pytensor
     import pytensor.tensor as pt
     from pymc.pytensorf import compile as compile_pymc
+    import pymc as pm
 
     shapes = _compute_shapes(model)
 
@@ -748,6 +787,37 @@ def _make_functions(
 
     num_expanded = count
 
+    log_likelihood_names = []
+    log_likelihood_shapes = []
+    log_likelihood_vars = []
+    
+    if compute_log_likelihood:
+        for obs in model.observed_RVs:
+            obs_name = obs.name
+            log_lik_name = f"log_likelihood_{obs_name}"
+            
+            # Get element-wise log-likelihood 
+            log_lik_expr = pm.logp(obs, obs)
+            log_lik_expr.name = log_lik_name
+            
+            # Get the shape of the observed variable
+            # For observed variables, we need to get the shape from the observed data
+            obs_shape = tuple(obs.shape.eval()) if hasattr(obs.shape, 'eval') else obs.shape
+            
+            log_likelihood_vars.append(log_lik_expr)
+            log_likelihood_names.append(log_lik_name)
+            log_likelihood_shapes.append(obs_shape)
+            
+            all_names.append(log_lik_name)
+            all_shapes.append(obs_shape)
+            length = prod(obs_shape)
+            all_slices.append(slice(count, count + length))
+            count += length
+        
+        num_expanded = count
+        
+        remaining_rvs.extend(log_likelihood_vars)
+
     if join_expanded:
         allvars = [pt.concatenate([joined, *[var.ravel() for var in remaining_rvs]])]
     else:
@@ -767,6 +837,7 @@ def _make_functions(
         expand_fn_pt,
         initial_point_fn,
         (all_names, all_slices, all_shapes),
+        (log_likelihood_names, log_likelihood_shapes),
     )
 
 

--- a/python/nutpie/compiled_pyfunc.py
+++ b/python/nutpie/compiled_pyfunc.py
@@ -1,5 +1,5 @@
 import dataclasses
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import partial
 from typing import Any, Callable
 
@@ -22,6 +22,8 @@ class PyFuncModel(CompiledModel):
     _coords: dict[str, Any]
     _raw_logp_fn: Callable | None
     _transform_adapt_args: dict | None = None
+    log_likelihood_names: list[str] = field(default_factory=list)
+    log_likelihood_shapes: list[tuple[int, ...]] = field(default_factory=list)
 
     @property
     def shapes(self) -> dict[str, tuple[int, ...]]:
@@ -104,6 +106,8 @@ def from_pyfunc(
     make_initial_point_fn: Callable[[SeedType], np.ndarray] | None = None,
     make_transform_adapter=None,
     raw_logp_fn=None,
+    log_likelihood_names: list[str] | None = None,
+    log_likelihood_shapes: list[tuple[int, ...]] | None = None,
 ):
     variables = []
     for name, shape, dtype in zip(
@@ -124,6 +128,10 @@ def from_pyfunc(
         dims = {}
     if shared_data is None:
         shared_data = {}
+    if log_likelihood_names is None:
+        log_likelihood_names = []
+    if log_likelihood_shapes is None:
+        log_likelihood_shapes = []
 
     return PyFuncModel(
         _n_dim=ndim,
@@ -135,4 +143,6 @@ def from_pyfunc(
         _variables=variables,
         _shared_data=shared_data,
         _raw_logp_fn=raw_logp_fn,
+        log_likelihood_names=log_likelihood_names,
+        log_likelihood_shapes=log_likelihood_shapes,
     )

--- a/tests/test_log_likelihood_integration.py
+++ b/tests/test_log_likelihood_integration.py
@@ -1,0 +1,176 @@
+"""
+Integration tests for log-likelihood calculation functionality.
+"""
+
+from importlib.util import find_spec
+import pytest
+import numpy as np
+
+if find_spec("pymc") is None:
+    pytest.skip("Skip pymc tests", allow_module_level=True)
+
+import pymc as pm
+import arviz as az
+import nutpie
+
+
+@pytest.mark.pymc
+def test_log_likelihood_compilation_numba():
+    """Test that compilation works with compute_log_likelihood=True for numba backend."""
+    np.random.seed(42)
+    observed_data = np.random.normal(0, 1, 10)
+    
+    with pm.Model() as model:
+        mu = pm.Normal("mu", mu=0, sigma=1)
+        y = pm.Normal("y", mu=mu, sigma=1, observed=observed_data)
+    
+    compiled_model = nutpie.compile_pymc_model(
+        model, 
+        backend="numba",
+        compute_log_likelihood=True
+    )
+    assert hasattr(compiled_model, 'log_likelihood_names')
+    assert hasattr(compiled_model, 'log_likelihood_shapes')
+    assert "log_likelihood_y" in compiled_model.log_likelihood_names
+    assert compiled_model.log_likelihood_shapes[0] == (10,)
+
+
+@pytest.mark.pymc
+def test_log_likelihood_compilation_disabled():
+    """Test that compilation works with compute_log_likelihood=False."""
+    np.random.seed(42)
+    observed_data = np.random.normal(0, 1, 10)
+    
+    with pm.Model() as model:
+        mu = pm.Normal("mu", mu=0, sigma=1)
+        y = pm.Normal("y", mu=mu, sigma=1, observed=observed_data)
+    
+    compiled_model = nutpie.compile_pymc_model(
+        model, 
+        backend="numba",
+        compute_log_likelihood=False
+    )
+    assert compiled_model.log_likelihood_names == []
+    assert compiled_model.log_likelihood_shapes == []
+
+
+@pytest.mark.pymc
+def test_log_likelihood_basic_sampling():
+    """Test basic sampling with log-likelihood calculation."""
+    np.random.seed(42)
+    observed_data = np.random.normal(2.0, 1.0, 20)
+    
+    with pm.Model() as model:
+        mu = pm.Normal("mu", mu=0, sigma=5)
+        sigma = pm.HalfNormal("sigma", sigma=2)
+        y = pm.Normal("y", mu=mu, sigma=sigma, observed=observed_data)
+    
+    compiled_model = nutpie.compile_pymc_model(
+        model, 
+        backend="numba",
+        compute_log_likelihood=True
+    )
+    trace = nutpie.sample(compiled_model, draws=10, tune=10, chains=1, cores=1)
+    
+    assert hasattr(trace, 'log_likelihood'), "log_likelihood group missing from InferenceData"
+    assert "log_likelihood_y" in trace.log_likelihood.data_vars, "log_likelihood_y not in log_likelihood group"
+    
+    log_lik = trace.log_likelihood["log_likelihood_y"]
+    assert log_lik.shape == (1, 10, 20), f"Expected shape (1, 10, 20), got {log_lik.shape}"
+    assert np.all(np.isfinite(log_lik.values)), "Log-likelihood values contain non-finite values"
+    assert not np.all(log_lik.values == 0), "Log-likelihood values are all zero"
+    assert np.all(log_lik.values <= 0), "Log-likelihood values should be non-positive"
+
+
+@pytest.mark.pymc
+def test_log_likelihood_multiple_observed():
+    """Test log-likelihood calculation with multiple observed variables."""
+    np.random.seed(42)
+    n_obs1, n_obs2 = 15, 10
+    observed_data1 = np.random.normal(1.0, 0.5, n_obs1)
+    observed_data2 = np.random.normal(-1.0, 1.0, n_obs2)
+    
+    with pm.Model() as model:
+        mu1 = pm.Normal("mu1", mu=0, sigma=2)
+        mu2 = pm.Normal("mu2", mu=0, sigma=2)
+        y1 = pm.Normal("y1", mu=mu1, sigma=0.5, observed=observed_data1)
+        y2 = pm.Normal("y2", mu=mu2, sigma=1.0, observed=observed_data2)
+    
+    compiled_model = nutpie.compile_pymc_model(
+        model, 
+        backend="numba",
+        compute_log_likelihood=True
+    )
+    assert len(compiled_model.log_likelihood_names) == 2
+    assert "log_likelihood_y1" in compiled_model.log_likelihood_names
+    assert "log_likelihood_y2" in compiled_model.log_likelihood_names
+    
+    y1_idx = compiled_model.log_likelihood_names.index("log_likelihood_y1")
+    y2_idx = compiled_model.log_likelihood_names.index("log_likelihood_y2")
+    
+    assert compiled_model.log_likelihood_shapes[y1_idx] == (n_obs1,)
+    assert compiled_model.log_likelihood_shapes[y2_idx] == (n_obs2,)
+    
+    trace = nutpie.sample(compiled_model, draws=8, tune=8, chains=1, cores=1)
+    assert "log_likelihood_y1" in trace.log_likelihood.data_vars
+    assert "log_likelihood_y2" in trace.log_likelihood.data_vars
+    
+    log_lik1 = trace.log_likelihood["log_likelihood_y1"]
+    log_lik2 = trace.log_likelihood["log_likelihood_y2"]
+    
+    assert log_lik1.shape == (1, 8, n_obs1)
+    assert log_lik2.shape == (1, 8, n_obs2)
+    
+    assert np.all(np.isfinite(log_lik1.values))
+    assert np.all(np.isfinite(log_lik2.values))
+    assert np.all(log_lik1.values <= 0)
+    assert np.all(log_lik2.values <= 0)
+
+
+@pytest.mark.pymc
+def test_log_likelihood_scalar_observed():
+    """Test log-likelihood calculation with scalar observed variable."""
+    np.random.seed(42)
+    observed_value = 3.5
+    
+    with pm.Model() as model:
+        mu = pm.Normal("mu", mu=0, sigma=2)
+        y = pm.Normal("y", mu=mu, sigma=1, observed=observed_value)
+    
+    compiled_model = nutpie.compile_pymc_model(
+        model, 
+        backend="numba",
+        compute_log_likelihood=True
+    )
+    assert "log_likelihood_y" in compiled_model.log_likelihood_names
+    y_idx = compiled_model.log_likelihood_names.index("log_likelihood_y")
+    assert compiled_model.log_likelihood_shapes[y_idx] == ()
+    trace = nutpie.sample(compiled_model, draws=6, tune=6, chains=1, cores=1)
+    
+    assert "log_likelihood_y" in trace.log_likelihood.data_vars
+    log_lik = trace.log_likelihood["log_likelihood_y"]
+    
+    assert log_lik.shape == (1, 6), f"Expected shape (1, 6), got {log_lik.shape}"
+    assert np.all(np.isfinite(log_lik.values))
+    assert np.all(log_lik.values <= 0)
+
+
+@pytest.mark.pymc
+def test_log_likelihood_backward_compatibility():
+    """Test that existing code without compute_log_likelihood still works."""
+    np.random.seed(42)
+    observed_data = np.random.normal(0, 1, 5)
+    
+    with pm.Model() as model:
+        mu = pm.Normal("mu", mu=0, sigma=1)
+        y = pm.Normal("y", mu=mu, sigma=1, observed=observed_data)
+    
+    compiled_model = nutpie.compile_pymc_model(model, backend="numba")
+    assert compiled_model.log_likelihood_names == []
+    assert compiled_model.log_likelihood_shapes == []
+    
+    trace = nutpie.sample(compiled_model, draws=5, tune=5, chains=1, cores=1)
+    if hasattr(trace, 'log_likelihood'):
+        assert len(trace.log_likelihood.data_vars) == 0
+    
+    assert "mu" in trace.posterior.data_vars


### PR DESCRIPTION
This allows nutpie to populate the `log_likelihood` group in ArviZ InferenceData objects when `compute_log_likelihood=True` is passed to `compile_pymc_model()`.

Closes #150 