### PR TITLE
Style the progressbar in the console

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -256,13 +256,13 @@ fn estimate_remaining_time(
 }
 
 #[derive(PartialEq, Eq)]
-pub enum ChainState {
+enum ChainState {
     Normal,
     Divergences,
     Finished,
 }
 
-pub struct TerminalBar {
+struct TerminalBar {
     pb: ProgressBar,
     last_position: u64,
     mode: ChainState,


### PR DESCRIPTION
This change makes the progress bar look closer to what's the default style in pymc