### PR TITLE
Exclude transformed variables from trace

### DIFF
--- a/.github/uv-constraints-dev.txt
+++ b/.github/uv-constraints-dev.txt
@@ -1,2 +1,2 @@
 pytensor @ git+https://github.com/pymc-devs/pytensor.git@main
-pymc @ git+https://github.com/pymc-devs/pymc.git@v6
+pymc @ git+https://github.com/pymc-devs/pymc.git@main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,4 @@ repos:
     rev: v1.24.1
     hooks:
     - id: zizmor
+      args: [--min-severity=medium]

--- a/python/nutpie/compile_pymc.py
+++ b/python/nutpie/compile_pymc.py
@@ -773,7 +773,6 @@ def _make_functions(
         with model:
             logp_fn_pt = compile_pymc((joined,), (logp,), mode=mode)
 
-    # Identify which joined variables have a transform applied
     transformed_value_names = set()
     for var in model.free_RVs:
         value_var = model.rvs_to_values[var]

--- a/python/nutpie/compile_pymc.py
+++ b/python/nutpie/compile_pymc.py
@@ -352,7 +352,6 @@ def _prepare_dims_and_coords(model, shape_info, unconstrained_info):
         if vals is None:
             vals = pd.RangeIndex(int(model.dim_lengths[name].eval()))
         idx = pd.Index(vals)
-        # Convert string indexes to plain lists so the Rust layer can handle them
         if idx.dtype == "object" or idx.dtype == "string":
             coords[name] = idx.tolist()
         else:
@@ -361,19 +360,7 @@ def _prepare_dims_and_coords(model, shape_info, unconstrained_info):
     if "unconstrained_parameter" in coords:
         raise ValueError("Model contains invalid name 'unconstrained_parameter'.")
 
-    # Build unconstrained_parameter coordinate from the unconstrained
-    # variable names/shapes (the full draw vector), which may differ from
-    # shape_info since shape_info excludes transformed variables from the trace.
-    unconstrained_names, unconstrained_shapes = unconstrained_info
-    names = []
-    for base, shape in zip(unconstrained_names, unconstrained_shapes):
-        for idx in itertools.product(*[range(length) for length in shape]):
-            if len(idx) == 0:
-                names.append(base)
-            else:
-                names.append(f"{base}_{'.'.join(str(i) for i in idx)}")
-    coords["unconstrained_parameter"] = names
-
+    unconstrained_names, unconstrained_shapes = unconstrained_info names = [] for base, shape in zip(unconstrained_names, unconstrained_shapes): for idx in itertools.product(*[range(length) for length in shape]): if len(idx) == 0: names.append(base) else: names.append(f"{base}_{'.'.join(str(i) for i in idx)}") coords["unconstrained_parameter"] = names
     dims = model.named_vars_to_dims
     return dims, coords
 

--- a/python/nutpie/compile_pymc.py
+++ b/python/nutpie/compile_pymc.py
@@ -360,7 +360,16 @@ def _prepare_dims_and_coords(model, shape_info, unconstrained_info):
     if "unconstrained_parameter" in coords:
         raise ValueError("Model contains invalid name 'unconstrained_parameter'.")
 
-    unconstrained_names, unconstrained_shapes = unconstrained_info names = [] for base, shape in zip(unconstrained_names, unconstrained_shapes): for idx in itertools.product(*[range(length) for length in shape]): if len(idx) == 0: names.append(base) else: names.append(f"{base}_{'.'.join(str(i) for i in idx)}") coords["unconstrained_parameter"] = names
+    unconstrained_names, unconstrained_shapes = unconstrained_info
+    names = []
+    for base, shape in zip(unconstrained_names, unconstrained_shapes):
+        for idx in itertools.product(*[range(length) for length in shape]):
+            if len(idx) == 0:
+                names.append(base)
+            else:
+                names.append(f"{base}_{'.'.join(str(i) for i in idx)}")
+    coords["unconstrained_parameter"] = names
+
     dims = model.named_vars_to_dims
     return dims, coords
 
@@ -780,9 +789,6 @@ def _make_functions(
         names = set(var_names)
         remaining_rvs = [var for var in remaining_rvs if var.name in names]
 
-    # Build trace variables: untransformed free variables + remaining variables
-    # Exclude transformed value variables (e.g. sigma_log__) since users want
-    # the original-scale versions (e.g. sigma) which are in remaining_rvs.
     all_names = []
     all_slices = []
     all_shapes = []

--- a/python/nutpie/compile_pymc.py
+++ b/python/nutpie/compile_pymc.py
@@ -32,6 +32,9 @@ if TYPE_CHECKING:
     from pytensor.tensor import TensorVariable, Variable
 
 
+_UNCONSTRAINED_PARAMETER = "unconstrained_parameter"
+
+
 def _rv_dict_to_flat_array_wrapper(
     fn: Callable[[SeedType | None], dict[str, np.ndarray]],
     names: list[str],
@@ -288,6 +291,7 @@ def _compile_pymc_model_numba(
         expand_fn_pt,
         initial_point_fn,
         shape_info,
+        reparameterized_names,
     ) = _make_functions(
         model,
         mode="NUMBA",
@@ -342,7 +346,7 @@ def _compile_pymc_model_numba(
 
         expand_numba = numba.cfunc(c_sig_expand, **kwargs)(expand_numba_raw)
 
-    dims, coords = _prepare_dims_and_coords(model, shape_info)
+    dims, coords = _prepare_dims_and_coords(model, shape_info, reparameterized_names)
 
     return CompiledPyMCModel(
         _n_dim=n_dim,
@@ -359,18 +363,19 @@ def _compile_pymc_model_numba(
         shape_info=shape_info,
         logp_func=logp_fn_pt,
         expand_func=expand_fn_pt,
+        reparameterized_names=reparameterized_names,
     )
 
 
-def _prepare_dims_and_coords(model, shape_info):
+def _prepare_dims_and_coords(model, shape_info, reparameterized_names):
     coords = {}
     for name, vals in model.coords.items():
         if vals is None:
             vals = pd.RangeIndex(int(model.dim_lengths[name].eval()))
         coords[name] = pd.Index(vals)
 
-    if "unconstrained_parameter" in coords:
-        raise ValueError("Model contains invalid name 'unconstrained_parameter'.")
+    if _UNCONSTRAINED_PARAMETER in coords:
+        raise ValueError(f"Model contains invalid name '{_UNCONSTRAINED_PARAMETER}'.")
 
     names = []
     for base, _, shape in zip(*shape_info):
@@ -381,9 +386,24 @@ def _prepare_dims_and_coords(model, shape_info):
                 names.append(base)
             else:
                 names.append(f"{base}_{'.'.join(str(i) for i in idx)}")
-    coords["unconstrained_parameter"] = pd.Index(names)
+    coords[_UNCONSTRAINED_PARAMETER] = pd.Index(names)
 
-    dims = model.named_vars_to_dims
+    names, _, shape_list = shape_info
+
+    shape_by_name = {n: tuple(s) for n, s in zip(names, shape_list)}
+    value_to_rv = {v.name: rv.name for v, rv in model.values_to_rvs.items()}
+
+    dims = dict(model.named_vars_to_dims)
+    for value_name in reparameterized_names:
+        rv_name = value_to_rv.get(value_name)
+        if rv_name is None:
+            continue
+        rv_dims = dims.get(rv_name)
+        if rv_dims is None:
+            continue
+        if shape_by_name.get(rv_name) == shape_by_name.get(value_name):
+            dims[value_name] = rv_dims
+
     return dims, coords
 
 
@@ -416,6 +436,7 @@ def _compile_pymc_model_jax(
         expand_fn_pt,
         initial_point_fn,
         shape_info,
+        reparameterized_names,
     ) = _make_functions(
         model,
         mode="JAX",
@@ -481,7 +502,7 @@ def _compile_pymc_model_jax(
 
         return expand
 
-    dims, coords = _prepare_dims_and_coords(model, shape_info)
+    dims, coords = _prepare_dims_and_coords(model, shape_info, reparameterized_names)
 
     return from_pyfunc(
         ndim=n_dim,
@@ -495,6 +516,7 @@ def _compile_pymc_model_jax(
         dims=dims,
         coords=coords,
         raw_logp_fn=orig_logp_fn,
+        reparameterized_names=reparameterized_names,
     )
 
 
@@ -658,6 +680,7 @@ def _make_functions(
     Callable,
     Callable,
     tuple[list[str], list[slice], list[tuple[int, ...]]],
+    list[str],
 ]:
     """
     Compile functions required by nuts-rs from a given PyMC model.
@@ -764,7 +787,7 @@ def _make_functions(
     if use_split:
         variables = pt.split(joined, splits, len(splits))
     else:
-        variables = [joined[slice_val] for slice_val in zip(joined_slices)]
+        variables = [joined[slice_val] for slice_val in joined_slices]
 
     replacements = {
         model.rvs_to_values[var]: value.reshape(shape).astype(var.dtype)
@@ -784,6 +807,12 @@ def _make_functions(
         with model:
             logp_fn_pt = compile_pymc((joined,), (logp,), mode=mode)
 
+    reparameterized_names = [
+        model.rvs_to_values[var].name
+        for var in model.free_RVs
+        if model.rvs_to_transforms.get(var) is not None
+    ]
+
     # Make function that computes remaining variables for the trace
     remaining_rvs = [
         var for var in model.unobserved_value_vars if var.name not in joined_names
@@ -793,11 +822,11 @@ def _make_functions(
         names = set(var_names)
         remaining_rvs = [var for var in remaining_rvs if var.name in names]
 
-    all_names = joined_names + remaining_rvs
-
     all_names = joined_names.copy()
     all_slices = joined_slices.copy()
     all_shapes = joined_shapes.copy()
+    count = num_free_vars
+    identity_free = list(variables)
 
     for var in remaining_rvs:
         all_names.append(var.name)
@@ -813,7 +842,7 @@ def _make_functions(
         allvars = [
             pt.concatenate(
                 [
-                    joined,
+                    *[v.ravel() for v in identity_free],
                     *[
                         pt.as_tensor(var, allow_xtensor_conversion=True).ravel()
                         for var in remaining_rvs
@@ -822,7 +851,7 @@ def _make_functions(
             )
         ]
     else:
-        allvars = [*variables, *remaining_rvs]
+        allvars = [*identity_free, *remaining_rvs]
     with model:
         expand_fn_pt = compile_pymc(
             (joined,),
@@ -838,6 +867,7 @@ def _make_functions(
         expand_fn_pt,
         initial_point_fn,
         (all_names, all_slices, all_shapes),
+        reparameterized_names,
     )
 
 

--- a/python/nutpie/compile_pymc.py
+++ b/python/nutpie/compile_pymc.py
@@ -273,6 +273,7 @@ def _compile_pymc_model_numba(
         expand_fn_pt,
         initial_point_fn,
         shape_info,
+        unconstrained_info,
     ) = _make_functions(
         model,
         mode="NUMBA",
@@ -326,7 +327,7 @@ def _compile_pymc_model_numba(
 
         expand_numba = numba.cfunc(c_sig_expand, **kwargs)(expand_numba_raw)
 
-    dims, coords = _prepare_dims_and_coords(model, shape_info)
+    dims, coords = _prepare_dims_and_coords(model, shape_info, unconstrained_info)
 
     return CompiledPyMCModel(
         _n_dim=n_dim,
@@ -345,26 +346,33 @@ def _compile_pymc_model_numba(
     )
 
 
-def _prepare_dims_and_coords(model, shape_info):
+def _prepare_dims_and_coords(model, shape_info, unconstrained_info):
     coords = {}
     for name, vals in model.coords.items():
         if vals is None:
             vals = pd.RangeIndex(int(model.dim_lengths[name].eval()))
-        coords[name] = pd.Index(vals)
+        idx = pd.Index(vals)
+        # Convert string indexes to plain lists so the Rust layer can handle them
+        if idx.dtype == "object" or idx.dtype == "string":
+            coords[name] = idx.tolist()
+        else:
+            coords[name] = idx
 
     if "unconstrained_parameter" in coords:
         raise ValueError("Model contains invalid name 'unconstrained_parameter'.")
 
+    # Build unconstrained_parameter coordinate from the unconstrained
+    # variable names/shapes (the full draw vector), which may differ from
+    # shape_info since shape_info excludes transformed variables from the trace.
+    unconstrained_names, unconstrained_shapes = unconstrained_info
     names = []
-    for base, _, shape in zip(*shape_info):
-        if base not in [var.name for var in model.value_vars]:
-            continue
+    for base, shape in zip(unconstrained_names, unconstrained_shapes):
         for idx in itertools.product(*[range(length) for length in shape]):
             if len(idx) == 0:
                 names.append(base)
             else:
                 names.append(f"{base}_{'.'.join(str(i) for i in idx)}")
-    coords["unconstrained_parameter"] = pd.Index(names)
+    coords["unconstrained_parameter"] = names
 
     dims = model.named_vars_to_dims
     return dims, coords
@@ -399,6 +407,7 @@ def _compile_pymc_model_jax(
         expand_fn_pt,
         initial_point_fn,
         shape_info,
+        unconstrained_info,
     ) = _make_functions(
         model,
         mode="JAX",
@@ -464,7 +473,7 @@ def _compile_pymc_model_jax(
 
         return expand
 
-    dims, coords = _prepare_dims_and_coords(model, shape_info)
+    dims, coords = _prepare_dims_and_coords(model, shape_info, unconstrained_info)
 
     return from_pyfunc(
         ndim=n_dim,
@@ -641,6 +650,7 @@ def _make_functions(
     Callable,
     Callable,
     tuple[list[str], list[slice], list[tuple[int, ...]]],
+    tuple[list[str], list[tuple[int, ...]]],
 ]:
     """
     Compile functions required by nuts-rs from a given PyMC model.
@@ -747,7 +757,7 @@ def _make_functions(
     if use_split:
         variables = pt.split(joined, splits, len(splits))
     else:
-        variables = [joined[slice_val] for slice_val in zip(joined_slices)]
+        variables = [joined[slice_val] for slice_val in joined_slices]
 
     replacements = {
         model.rvs_to_values[var]: value.reshape(shape).astype(var.dtype)
@@ -767,6 +777,13 @@ def _make_functions(
         with model:
             logp_fn_pt = compile_pymc((joined,), (logp,), mode=mode)
 
+    # Identify which joined variables have a transform applied
+    transformed_value_names = set()
+    for var in model.free_RVs:
+        value_var = model.rvs_to_values[var]
+        if model.rvs_to_transforms.get(var) is not None:
+            transformed_value_names.add(value_var.name)
+
     # Make function that computes remaining variables for the trace
     remaining_rvs = [
         var for var in model.unobserved_value_vars if var.name not in joined_names
@@ -776,27 +793,39 @@ def _make_functions(
         names = set(var_names)
         remaining_rvs = [var for var in remaining_rvs if var.name in names]
 
-    all_names = joined_names + remaining_rvs
+    # Build trace variables: untransformed free variables + remaining variables
+    # Exclude transformed value variables (e.g. sigma_log__) since users want
+    # the original-scale versions (e.g. sigma) which are in remaining_rvs.
+    all_names = []
+    all_slices = []
+    all_shapes = []
+    count_expanded = 0
 
-    all_names = joined_names.copy()
-    all_slices = joined_slices.copy()
-    all_shapes = joined_shapes.copy()
+    untransformed_free = []
+    for var_expr, name, shape in zip(variables, joined_names, joined_shapes):
+        if name not in transformed_value_names:
+            length = prod(shape)
+            all_names.append(name)
+            all_shapes.append(shape)
+            all_slices.append(slice(count_expanded, count_expanded + length))
+            count_expanded += length
+            untransformed_free.append(var_expr)
 
     for var in remaining_rvs:
         all_names.append(var.name)
         shape = cast(tuple[int, ...], shapes[var.name])
         all_shapes.append(shape)
         length = prod(shape)
-        all_slices.append(slice(count, count + length))
-        count += length
+        all_slices.append(slice(count_expanded, count_expanded + length))
+        count_expanded += length
 
-    num_expanded = count
+    num_expanded = count_expanded
 
     if join_expanded:
         allvars = [
             pt.concatenate(
                 [
-                    joined,
+                    *[v.ravel() for v in untransformed_free],
                     *[
                         pt.as_tensor(var, allow_xtensor_conversion=True).ravel()
                         for var in remaining_rvs
@@ -805,7 +834,7 @@ def _make_functions(
             )
         ]
     else:
-        allvars = [*variables, *remaining_rvs]
+        allvars = [*untransformed_free, *remaining_rvs]
     with model:
         expand_fn_pt = compile_pymc(
             (joined,),
@@ -821,6 +850,7 @@ def _make_functions(
         expand_fn_pt,
         initial_point_fn,
         (all_names, all_slices, all_shapes),
+        (joined_names, joined_shapes),
     )
 
 

--- a/python/nutpie/compiled_pyfunc.py
+++ b/python/nutpie/compiled_pyfunc.py
@@ -119,6 +119,7 @@ def from_pyfunc(
     make_initial_point_fn: Callable[[SeedType], np.ndarray] | None = None,
     make_transform_adapter=None,
     raw_logp_fn=None,
+    reparameterized_names=None,
 ):
     if coords is None:
         coords = {}
@@ -150,4 +151,5 @@ def from_pyfunc(
         _variables=variables,
         _shared_data=shared_data,
         _raw_logp_fn=raw_logp_fn,
+        reparameterized_names=reparameterized_names,
     )

--- a/python/nutpie/sample.py
+++ b/python/nutpie/sample.py
@@ -119,7 +119,8 @@ def _arrow_to_arviz(
     }
 
     arviz_version = version("arviz")
-    if tuple(map(int, arviz_version.split(".")[:2])) >= (1, 0):
+    use_datatree = tuple(map(int, arviz_version.split(".")[:2])) >= (1, 0)
+    if use_datatree:
         idata = arviz.from_dict(
             {
                 "posterior": data_posterior,
@@ -154,7 +155,10 @@ def _arrow_to_arviz(
             groups["warmup_unconstrained_posterior"] = arviz.dict_to_dataset(
                 uc_data_tune, coords=coords, dims=uc_dims
             )
-        idata.add_groups(groups)
+        if use_datatree:
+            idata = idata.assign(**{k: xr.DataTree(v) for k, v in groups.items()})
+        else:
+            idata.add_groups(groups)
 
     return idata
 

--- a/python/nutpie/sample.py
+++ b/python/nutpie/sample.py
@@ -1,6 +1,7 @@
 import os
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from importlib.metadata import version
 from typing import Any, Literal, Optional, cast, get_args, overload
 
 import arviz
@@ -15,6 +16,7 @@ from nutpie import _lib
 @dataclass(frozen=True)
 class CompiledModel:
     dims: Optional[dict[str, tuple[str, ...]]]
+    reparameterized_names: list[str] | None = field(default=None, kw_only=True)
 
     @property
     def n_dim(self) -> int:
@@ -56,9 +58,18 @@ class CompiledModel:
         return pd.concat(times)
 
 
-def _arrow_to_arviz(draw_batches, stat_batches, skip_vars=None, **kwargs):
+def _arrow_to_arviz(
+    draw_batches,
+    stat_batches,
+    skip_vars=None,
+    reparameterized_names=None,
+    keep_unconstrained_draw=False,
+    **kwargs,
+):
     if skip_vars is None:
         skip_vars = []
+    if reparameterized_names is None:
+        reparameterized_names = []
 
     n_chains = len(draw_batches)
     assert n_chains == len(stat_batches)
@@ -98,11 +109,18 @@ def _arrow_to_arviz(draw_batches, stat_batches, skip_vars=None, **kwargs):
             stats_posterior, max_posterior, stat_posterior, i, n_chains, dims, skip_vars
         )
 
-    from importlib.metadata import version
+    uc_data_posterior = {
+        name: data_posterior.pop(name)
+        for name in reparameterized_names
+        if name in data_posterior
+    }
+    uc_data_tune = {
+        name: data_tune.pop(name) for name in reparameterized_names if name in data_tune
+    }
 
     arviz_version = version("arviz")
     if tuple(map(int, arviz_version.split(".")[:2])) >= (1, 0):
-        return arviz.from_dict(
+        idata = arviz.from_dict(
             {
                 "posterior": data_posterior,
                 "sample_stats": stats_posterior,
@@ -113,7 +131,7 @@ def _arrow_to_arviz(draw_batches, stat_batches, skip_vars=None, **kwargs):
             **kwargs,
         )
     else:
-        return arviz.from_dict(
+        idata = arviz.from_dict(
             **{
                 "posterior": data_posterior,
                 "sample_stats": stats_posterior,
@@ -123,6 +141,22 @@ def _arrow_to_arviz(draw_batches, stat_batches, skip_vars=None, **kwargs):
             dims=dims,
             **kwargs,
         )
+
+    if keep_unconstrained_draw and uc_data_posterior:
+        coords = kwargs.get("coords")
+        uc_dims = {name: dims.get(name, []) for name in uc_data_posterior}
+        groups = {
+            "unconstrained_posterior": arviz.dict_to_dataset(
+                uc_data_posterior, coords=coords, dims=uc_dims
+            )
+        }
+        if uc_data_tune:
+            groups["warmup_unconstrained_posterior"] = arviz.dict_to_dataset(
+                uc_data_tune, coords=coords, dims=uc_dims
+            )
+        idata.add_groups(groups)
+
+    return idata
 
 
 def _add_arrow_data(data_dict, max_length, batch, chain, n_chains, dims, skip_vars):
@@ -466,11 +500,13 @@ class _BackgroundSampler:
         progress_style=None,
         progress_rate=100,
         store=None,
+        store_unconstrained=False,
     ):
         self._settings = settings
         self._compiled_model = compiled_model
         self._save_warmup = save_warmup
         self._return_raw_trace = return_raw_trace
+        self._store_unconstrained = store_unconstrained
 
         self._html = None
 
@@ -625,6 +661,8 @@ class _BackgroundSampler:
                     draw_batches,
                     stat_batches,
                     skip_vars=skip_vars,
+                    reparameterized_names=self._compiled_model.reparameterized_names,
+                    keep_unconstrained_draw=self._store_unconstrained,
                     coords={
                         name: pd.Index(vals)
                         for name, vals in self._compiled_model.coords.items()
@@ -690,6 +728,7 @@ def sample(
     progress_style: str | None = None,
     progress_rate: int = 100,
     zarr_store: _ZarrStoreType | None = None,
+    store_unconstrained: bool = False,
 ) -> xr.DataTree: ...
 
 
@@ -713,6 +752,7 @@ def sample(
     progress_style: str | None = None,
     progress_rate: int = 100,
     zarr_store: _ZarrStoreType | None = None,
+    store_unconstrained: bool = False,
     **kwargs,
 ) -> xr.DataTree: ...
 
@@ -737,6 +777,7 @@ def sample(
     progress_style: str | None = None,
     progress_rate: int = 100,
     zarr_store: _ZarrStoreType | None = None,
+    store_unconstrained: bool = False,
     **kwargs,
 ) -> _BackgroundSampler: ...
 
@@ -784,6 +825,7 @@ def sample(
     progress_style: str | None = None,
     progress_rate: int = 100,
     zarr_store: _ZarrStoreType | None = None,
+    store_unconstrained: bool = False,
     **kwargs,
 ) -> xr.DataTree | _BackgroundSampler:
     """Sample the posterior distribution for a compiled model.
@@ -820,8 +862,11 @@ def sample(
         point on the transformed parameter space. Defaults to
         zeros.
     store_unconstrained: bool
-        If True, store each draw in the unconstrained (transformed)
-        space in the sample stats.
+        If True, store the unconstrained (transformed) draws in two forms:
+        a flat ``unconstrained_draw`` vector in ``sample_stats`` and a
+        per-variable ``unconstrained_posterior`` group (with
+        ``warmup_unconstrained_posterior`` when ``save_warmup=True``) whose
+        dims are copied from the corresponding RV.
     store_gradient: bool
         If True, store the logp gradient of each draw in the unconstrained
         space in the sample stats.
@@ -995,6 +1040,9 @@ def sample(
 
     settings.update(updates)
 
+    if store_unconstrained:
+        settings.store_unconstrained = True
+
     if cores is None:
         try:
             # Only available in python>=3.13
@@ -1022,6 +1070,7 @@ def sample(
         progress_style=progress_style,
         progress_rate=progress_rate,
         store=zarr_store,
+        store_unconstrained=store_unconstrained,
     )
 
     if not blocking:

--- a/tests/test_pymc.py
+++ b/tests/test_pymc.py
@@ -305,7 +305,11 @@ def test_pymc_model_with_coordinate(backend, gradient_backend):
 def test_pymc_model_store_extra(backend, gradient_backend):
     with pm.Model() as model:
         model.add_coord("foo", length=5)
+        model.add_coord("bar", length=4)
         pm.Normal("a", dims="foo")
+        pm.HalfNormal("b", sigma=1.0, dims="foo")
+        pm.ZeroSumNormal("c", sigma=1.0, dims="foo")
+        pm.Dirichlet("d", a=np.ones(4), dims="bar")
 
     compiled = nutpie.compile_pymc_model(
         model, backend=backend, gradient_backend=gradient_backend
@@ -319,6 +323,26 @@ def test_pymc_model_store_extra(backend, gradient_backend):
         store_gradient=True,
     )
     trace.posterior.a  # noqa: B018
+    trace.posterior.b  # noqa: B018
+    trace.posterior.c  # noqa: B018
+    trace.posterior.d  # noqa: B018
+    assert trace.posterior.c.dims == ("chain", "draw", "foo")
+    assert trace.posterior.d.dims == ("chain", "draw", "bar")
+    assert trace.unconstrained_posterior.b_log__.dims == ("chain", "draw", "foo")
+    # ZeroSumNormal's unconstrained value has one fewer element along the
+    # zero-sum axis, so it should NOT inherit the "foo" dim.
+    assert trace.unconstrained_posterior.c_zerosum__.dims != (
+        "chain",
+        "draw",
+        "foo",
+    )
+    # Dirichlet's simplex transform reduces dimensionality by one, so it
+    # should NOT inherit the "bar" dim.
+    assert trace.unconstrained_posterior.d_simplex__.dims != (
+        "chain",
+        "draw",
+        "bar",
+    )
     _ = trace.sample_stats.unconstrained_draw
     _ = trace.sample_stats.gradient
     _ = trace.sample_stats.divergence_start


### PR DESCRIPTION
Skip transformed names when building the expand function output and shape_info. 

Following from this, there are changes in the construction of the `unconstrained_parameter` coordinate. Since shape_info no longer contains transformed names, that broke store_unconstrained=True. Here,  `_make_functions` now also returns `(joined_names, joined_shapes)` — the full unconstrained parameter space. _prepare_dims_and_coords uses this  directly to build the coordinate, decoupling it from shape_info.