### PR TITLE
Fix progress bar not displaying in Databricks notebooks

### DIFF
--- a/python/nutpie/sample.py
+++ b/python/nutpie/sample.py
@@ -399,6 +399,9 @@ def in_notebook():
 
     if in_colab():
         return True
+    # Databricks sets this env var on all cluster runtimes (same check as rich)
+    if os.getenv("DATABRICKS_RUNTIME_VERSION"):
+        return True
     try:
         shell = get_ipython().__class__.__name__  # type: ignore
         if shell == "ZMQInteractiveShell":  # Jupyter notebook, Spyder or qtconsole


### PR DESCRIPTION
## Summary

- Databricks notebooks use a custom IPython shell class that does not identify as `ZMQInteractiveShell`, causing `in_notebook()` to return `False` and falling back to the terminal (`indicatif`) renderer which produces no visible output
- Adds a check for the `DATABRICKS_RUNTIME_VERSION` environment variable, which Databricks sets automatically on all cluster runtimes — the same approach used by `rich`

## References

- Fixes #218
- Approach mirrors [`rich`'s `_is_jupyter()` implementation](https://github.com/Textualize/rich/blob/master/rich/console.py)