### PR TITLE
Make zarr traces equivalent to arrow traces

### DIFF
--- a/python/nutpie/sample.py
+++ b/python/nutpie/sample.py
@@ -623,6 +623,7 @@ class _BackgroundSampler:
                 "mass_matrix_inv",
                 "mass_matrix_eigvals",
                 "mass_matrix_stds",
+                "transformation_mu",
             ],
             "store_divergences": [
                 "divergence_start",
@@ -630,11 +631,7 @@ class _BackgroundSampler:
                 "divergence_momentum",
                 "divergence_start_gradient",
             ],
-            "store_transformed": [
-                "transformed_position",
-                "transformed_gradient",
-                "transformation_mu",
-            ],
+            "store_transformed": ["transformed_position", "transformed_gradient"],
         }
 
         def _get_nested(settings, name, default):

--- a/python/nutpie/sample.py
+++ b/python/nutpie/sample.py
@@ -693,6 +693,22 @@ class _BackgroundSampler:
                     for name in ("warmup_posterior", "warmup_sample_stats"):
                         if name in trace:
                             del trace[name]
+                # the zarr writer leaves the unconstrained value variables in `posterior`;
+                # the arrow backend moves them out, into their own group when asked for them
+                uc_names = self._compiled_model.reparameterized_names or []
+                for group, uc_group in (
+                    ("posterior", "unconstrained_posterior"),
+                    ("warmup_posterior", "warmup_unconstrained_posterior"),
+                ):
+                    if group not in trace:
+                        continue
+                    dataset = trace[group].dataset
+                    present = [name for name in uc_names if name in dataset.data_vars]
+                    if not present:
+                        continue
+                    if self._store_unconstrained:
+                        trace[uc_group] = xr.DataTree(dataset[present])
+                    trace[group].dataset = dataset.drop_vars(present)
                 # dict attrs have no HDF5 equivalent; keep the tree to_netcdf-able
                 for node in trace.subtree:
                     for key, value in list(node.attrs.items()):

--- a/python/nutpie/sample.py
+++ b/python/nutpie/sample.py
@@ -605,6 +605,51 @@ class _BackgroundSampler:
         results = self._sampler.take_results()
         return self._extract(results)
 
+    def _sample_stats_attrs(self):
+        from nutpie import __version__
+
+        return {
+            "inference_library": "nutpie",
+            "inference_library_version": __version__,
+            "inference_library_settings": json.dumps(self._settings.as_dict()),
+        }
+
+    def _skipped_stats(self, settings_dict):
+        """Sampler stats the settings say not to store, and so should not reach the trace."""
+        skips = {
+            "store_gradient": ["gradient"],
+            "store_unconstrained": ["unconstrained_draw"],
+            "adapt_options.mass_matrix_options.store_mass_matrix": [
+                "mass_matrix_inv",
+                "mass_matrix_eigvals",
+                "mass_matrix_stds",
+            ],
+            "store_divergences": [
+                "divergence_start",
+                "divergence_end",
+                "divergence_momentum",
+                "divergence_start_gradient",
+            ],
+            "store_transformed": [
+                "transformed_position",
+                "transformed_gradient",
+                "transformation_mu",
+            ],
+        }
+
+        def _get_nested(settings, name, default):
+            for part in name.split("."):
+                if part not in settings:
+                    return default
+                settings = settings[part]
+            return settings
+
+        skip_vars = []
+        for setting, names in skips.items():
+            if not _get_nested(settings_dict["settings"], setting, False):
+                skip_vars.extend(names)
+        return skip_vars
+
     def _extract(self, results):
         settings_dict = self._settings.as_dict()
         if self._return_raw_trace:
@@ -622,52 +667,45 @@ class _BackgroundSampler:
                 store = cls(*args, **kwargs)
 
                 obj_store = ObjectStore(store, read_only=True)
-                return xr.open_datatree(obj_store, engine="zarr", consolidated=False)  # ty:ignore[invalid-argument-type]
+                trace = xr.open_datatree(obj_store, engine="zarr", consolidated=False)  # ty:ignore[invalid-argument-type]
+                # match the arrow backend, pymc reads these from sample_stats
+                if "sample_stats" in trace:
+                    trace["sample_stats"].attrs.update(self._sample_stats_attrs())
+                # the settings say which stats to store; the zarr writer stores them all
+                skip_vars = set(self._skipped_stats(settings_dict))
+                # label chain/draw as the arrow backend does (assigning in place stays lazy and
+                # keeps each node's children)
+                for node in trace.subtree:
+                    dataset = node.dataset
+                    missing = {
+                        dim: np.arange(dataset.sizes[dim])
+                        for dim in ("chain", "draw")
+                        if dim in dataset.dims and dim not in dataset.coords
+                    }
+                    stale = (
+                        skip_vars & set(dataset.data_vars)
+                        if (node.name or "").endswith("sample_stats")
+                        else set()
+                    )
+                    if missing or stale:
+                        node.dataset = dataset.drop_vars(stale).assign_coords(missing)
+                if not self._save_warmup:
+                    for name in ("warmup_posterior", "warmup_sample_stats"):
+                        if name in trace:
+                            del trace[name]
+                # dict attrs have no HDF5 equivalent; keep the tree to_netcdf-able
+                for node in trace.subtree:
+                    for key, value in list(node.attrs.items()):
+                        if isinstance(value, dict):
+                            node.attrs[key] = json.dumps(value)
+                return trace
 
             elif results.is_arrow():
-                skip_vars = []
-                skips = {
-                    "store_gradient": ["gradient"],
-                    "store_unconstrained": ["unconstrained_draw"],
-                    "adapt_options.mass_matrix_options.store_mass_matrix": [
-                        "mass_matrix_inv",
-                        "mass_matrix_eigvals",
-                        "mass_matrix_stds",
-                    ],
-                    "store_divergences": [
-                        "divergence_start",
-                        "divergence_end",
-                        "divergence_momentum",
-                        "divergence_start_gradient",
-                    ],
-                    "store_transformed": [
-                        "transformed_position",
-                        "transformed_gradient",
-                        "transformation_mu",
-                    ],
-                }
-
-                def _get_nested(settings, name, default):
-                    parts = name.split(".")
-                    for part in parts:
-                        if part not in settings:
-                            return default
-                        settings = settings[part]
-                    return settings
-
-                for setting, names in skips.items():
-                    if not _get_nested(settings_dict["settings"], setting, False):
-                        skip_vars.extend(names)
+                skip_vars = self._skipped_stats(settings_dict)
 
                 draw_batches, stat_batches = results.get_arrow_trace()
 
-                from nutpie import __version__
-
-                attrs = {
-                    "inference_library": "nutpie",
-                    "inference_library_version": __version__,
-                    "inference_library_settings": json.dumps(self._settings.as_dict()),
-                }
+                attrs = self._sample_stats_attrs()
 
                 return _arrow_to_arviz(
                     draw_batches,

--- a/tests/test_pymc.py
+++ b/tests/test_pymc.py
@@ -1,3 +1,4 @@
+import json
 import time
 from importlib.util import find_spec
 
@@ -650,3 +651,52 @@ def test_unnamed_shared(backend, gradient_backend):
 
     compiled = nutpie.compile_pymc_model(model)
     nutpie.sample(compiled)
+
+
+def test_zarr_store_sample_stats_attrs(tmp_path):
+    """The zarr backend must attach the same sample_stats attrs as the arrow backend.
+
+    pymc's ``patch_nutpie_idata`` reads ``inference_library_settings`` from there, so
+    ``pm.sample(nuts_sampler="nutpie", nuts_sampler_kwargs={"zarr_store": ...})``
+    fails with a KeyError when they are missing.
+    """
+    with pm.Model() as model:
+        pm.Normal("x")
+
+    compiled = nutpie.compile_pymc_model(model, backend="numba")
+
+    path = tmp_path / "trace.zarr"
+    path.mkdir()
+    store = nutpie.zarr_store.LocalStore(str(path))
+    zarr_trace = nutpie.sample(
+        compiled, chains=1, seed=123, draws=20, tune=20, zarr_store=store
+    )
+    arrow_trace = nutpie.sample(compiled, chains=1, seed=123, draws=20, tune=20)
+
+    for key in [
+        "inference_library",
+        "inference_library_version",
+        "inference_library_settings",
+    ]:
+        assert key in zarr_trace.sample_stats.attrs, key
+        assert (
+            zarr_trace.sample_stats.attrs[key] == arrow_trace.sample_stats.attrs[key]
+        ), key
+
+    settings = json.loads(zarr_trace.sample_stats.attrs["inference_library_settings"])
+    assert settings["settings"]["num_tune"] == 20
+
+    # the store keeps every stat and both warmup groups; the settings say otherwise
+    assert set(zarr_trace.sample_stats.data_vars) == set(arrow_trace.sample_stats.data_vars)
+    assert set(zarr_trace.children) == set(arrow_trace.children)
+
+    # chain/draw carry coordinate variables, so label-based selection works
+    assert "chain" in zarr_trace.posterior.coords
+    assert "draw" in zarr_trace.posterior.coords
+    zarr_trace.posterior.sel(draw=5)
+
+    # no dict-valued attrs remain anywhere: the tree must survive to_netcdf
+    for node in zarr_trace.subtree:
+        for value in node.attrs.values():
+            assert not isinstance(value, dict)
+    zarr_trace.to_netcdf(tmp_path / "roundtrip.nc")

--- a/tests/test_pymc.py
+++ b/tests/test_pymc.py
@@ -653,13 +653,10 @@ def test_unnamed_shared(backend, gradient_backend):
     nutpie.sample(compiled)
 
 
+@pytest.mark.pymc
 def test_zarr_store_sample_stats_attrs(tmp_path):
-    """The zarr backend must attach the same sample_stats attrs as the arrow backend.
-
-    pymc's ``patch_nutpie_idata`` reads ``inference_library_settings`` from there, so
-    ``pm.sample(nuts_sampler="nutpie", nuts_sampler_kwargs={"zarr_store": ...})``
-    fails with a KeyError when they are missing.
-    """
+    """The zarr trace must carry the same sample_stats attrs, coords and stat set as arrow:
+    pymc's ``patch_nutpie_idata`` reads ``inference_library_settings`` from there."""
     with pm.Model() as model:
         pm.Normal("x")
 
@@ -704,13 +701,10 @@ def test_zarr_store_sample_stats_attrs(tmp_path):
     zarr_trace.to_netcdf(tmp_path / "roundtrip.nc")
 
 
+@pytest.mark.pymc
 def test_zarr_store_transformed_variables(tmp_path):
-    """Unconstrained value variables belong out of ``posterior``, on both backends.
-
-    The zarr writer stores every variable it is handed, including each free RV's
-    transformed value var; the arrow backend pops those into ``unconstrained_posterior``
-    and only keeps them when ``store_unconstrained=True``.
-    """
+    """Unconstrained value variables belong out of ``posterior`` on both backends, and in
+    ``unconstrained_posterior`` only when ``store_unconstrained=True``."""
     with pm.Model() as model:
         sigma = pm.HalfNormal("sigma")  # gives a sigma_log__ value variable
         pm.Normal("mu", 0.0, sigma)
@@ -720,13 +714,13 @@ def test_zarr_store_transformed_variables(tmp_path):
     def fit(store_unconstrained, name):
         path = tmp_path / name
         path.mkdir()
-        kwargs = dict(
-            chains=1,
-            seed=123,
-            draws=20,
-            tune=20,
-            store_unconstrained=store_unconstrained,
-        )
+        kwargs = {
+            "chains": 1,
+            "seed": 123,
+            "draws": 20,
+            "tune": 20,
+            "store_unconstrained": store_unconstrained,
+        }
         store = nutpie.zarr_store.LocalStore(str(path))
         return (
             nutpie.sample(compiled, zarr_store=store, **kwargs),

--- a/tests/test_pymc.py
+++ b/tests/test_pymc.py
@@ -687,7 +687,9 @@ def test_zarr_store_sample_stats_attrs(tmp_path):
     assert settings["settings"]["num_tune"] == 20
 
     # the store keeps every stat and both warmup groups; the settings say otherwise
-    assert set(zarr_trace.sample_stats.data_vars) == set(arrow_trace.sample_stats.data_vars)
+    assert set(zarr_trace.sample_stats.data_vars) == set(
+        arrow_trace.sample_stats.data_vars
+    )
     assert set(zarr_trace.children) == set(arrow_trace.children)
 
     # chain/draw carry coordinate variables, so label-based selection works
@@ -700,3 +702,45 @@ def test_zarr_store_sample_stats_attrs(tmp_path):
         for value in node.attrs.values():
             assert not isinstance(value, dict)
     zarr_trace.to_netcdf(tmp_path / "roundtrip.nc")
+
+
+def test_zarr_store_transformed_variables(tmp_path):
+    """Unconstrained value variables belong out of ``posterior``, on both backends.
+
+    The zarr writer stores every variable it is handed, including each free RV's
+    transformed value var; the arrow backend pops those into ``unconstrained_posterior``
+    and only keeps them when ``store_unconstrained=True``.
+    """
+    with pm.Model() as model:
+        sigma = pm.HalfNormal("sigma")  # gives a sigma_log__ value variable
+        pm.Normal("mu", 0.0, sigma)
+
+    compiled = nutpie.compile_pymc_model(model, backend="numba")
+
+    def fit(store_unconstrained, name):
+        path = tmp_path / name
+        path.mkdir()
+        kwargs = dict(
+            chains=1,
+            seed=123,
+            draws=20,
+            tune=20,
+            store_unconstrained=store_unconstrained,
+        )
+        store = nutpie.zarr_store.LocalStore(str(path))
+        return (
+            nutpie.sample(compiled, zarr_store=store, **kwargs),
+            nutpie.sample(compiled, **kwargs),
+        )
+
+    zarr_trace, arrow_trace = fit(False, "default.zarr")
+    assert set(zarr_trace.posterior.data_vars) == set(arrow_trace.posterior.data_vars)
+    assert "sigma_log__" not in zarr_trace.posterior.data_vars
+    assert "unconstrained_posterior" not in zarr_trace.children
+
+    zarr_trace, arrow_trace = fit(True, "unconstrained.zarr")
+    assert "sigma_log__" not in zarr_trace.posterior.data_vars
+    assert "sigma_log__" in zarr_trace.unconstrained_posterior.data_vars
+    assert set(zarr_trace.unconstrained_posterior.data_vars) == set(
+        arrow_trace.unconstrained_posterior.data_vars
+    )


### PR DESCRIPTION
## What / why

A trace returned from a `zarr_store` (added in #244, following the request in #171) currently
diverges from the arrow backend in five ways that break downstream consumers:

1. **Missing `sample_stats` attrs.** The arviz-convention attrs added in 74519195
   (`inference_library`, `inference_library_version`, `inference_library_settings`) are only
   set on the arrow path. PyMC's `patch_nutpie_idata` reads them, so

   ```python
   pm.sample(nuts_sampler="nutpie", nuts_sampler_kwargs={"zarr_store": store})
   ```

   fails with `KeyError: 'inference_library_settings'` — the zarr backend is unusable through
   PyMC without monkeypatching.
2. **No `chain`/`draw` coordinate variables.** They exist as dimensions only, so label-based
   selection (`posterior.sel(draw=...)`) raises `KeyError` on zarr traces where it works on
   arrow ones.
3. **Dict-valued attrs.** Fine in zarr, but with no HDF5 equivalent, so a later
   `to_netcdf()` of the tree fails with `TypeError: Object dtype has no native HDF5
   equivalent`.
4. **`save_warmup` and the `store_*` settings are ignored.** The trace keeps both warmup groups
   and ten per-draw, parameter-sized stats (`gradient`, `unconstrained_draw`, `mass_matrix_*`,
   `divergence_*`, `transformed_*`) that the arrow backend drops. On a small PyMC model that is
   an **8x larger stored trace**, and the ratio grows with the parameter count — it inflates every
   saved trace, every re-read, and the peak memory of writing one out.

5. **Transformed variables stay in `posterior`.** The zarr trace keeps every unconstrained
   value variable (`sigma_log__`, ...) in its `posterior` group; the arrow trace does not. On one
   production model that is 174 posterior variables against arrow's 116 — 58 extras, at full draw
   width and carrying auto-generated dimension names that downstream consumers don't expect.

   Both backends are handed the same list: `_make_functions` always includes each free RV's
   transformed value-var name in `all_names`/`shape_info[0]`, and `var_names` only prunes
   `remaining_rvs`, never the value vars — confirmed with `return_raw_trace=True`, where the raw
   arrow trace contains `sigma_log__` too. nuts-rs stores what it is told, identically for both
   (`arrow.rs` and `zarr/sync_impl.rs` call the same `settings.data_types(math)`). The difference
   is created afterwards: the arrow branch calls `_arrow_to_arviz`, which pops
   `reparameterized_names` and only resurfaces them, as `unconstrained_posterior`, when
   `store_unconstrained=True`; the zarr branch returned the tree verbatim.

The fix handles all five in the zarr branch of `_extract`. The attrs and the skip-list are hoisted
into `_sample_stats_attrs()` / `_skipped_stats()` helpers used by *both* paths, so the two backends
cannot drift again; `chain`/`draw` are labelled `0..n-1` as on the arrow path; dict attrs are
JSON-encoded the way `inference_library_settings` already is; and the stats and warmup groups the
settings exclude are dropped; and the unconstrained value
variables are moved out of `posterior` using `reparameterized_names`, the same list the arrow path
uses, so `store_unconstrained` means the same thing on both backends. Coords and vars are assigned per node **in place**, so the tree stays
lazy and keeps any children (`tree[path] = dataset` would replace the node and discard them).

Motivation/context: #171 asked for the zarr backend precisely so that "pymc would then be
able to simply load the trace from the underlying storage without much need to nutpie
wrappers" — this makes that hold in practice. It also matters for the memory threads (#233,
#265): streaming to a `zarr_store` keeps sampling-phase memory flat instead of accumulating
the trace in RAM, but only if the resulting trace is actually consumable downstream.

One behavioural note: the arrow path adds `warmup_unconstrained_posterior` even when
`save_warmup=False`. The zarr path here handles the unconstrained groups *after* dropping warmup,
so it does not — that looked like the intended behaviour rather than something to mirror, but say
the word and I'll match arrow exactly instead.

## Test plan

- `tests/test_pymc.py::test_zarr_store_sample_stats_attrs` (new) — asserts attr parity
  between the zarr and arrow trace, that `num_tune` (the field PyMC dereferences)
  round-trips, that `sel(draw=...)` works, that the tree survives `to_netcdf()`, and that both
  backends return the same groups and the same sampler stats.
- `tests/test_pymc.py::test_zarr_store_transformed_variables` (new) — asserts that a
  `HalfNormal`'s `sigma_log__` is absent from `posterior` on both backends by default, and that
  with `store_unconstrained=True` both put the same variables in `unconstrained_posterior`.
- Existing zarr test passes unchanged; verified end to end that
  `pm.sample(..., zarr_store=...)` completes with no shims on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


